### PR TITLE
Add cmds to jump to the prev/next sibling and to mark the current thread as read

### DIFF
--- a/retronews.py
+++ b/retronews.py
@@ -716,6 +716,39 @@ def cmd_next_unread(app: AppState) -> None:
     if message is not None:
         app_select_message(app, message)
 
+def cmd_next_sibling(app: AppState) -> None:
+    if (msg := app.selected_message) is not None and (parent_msg := msg.parent) is not None:
+        # find the next sibling
+        try:
+            idx = parent_msg.children.index(msg)
+            if idx < len(parent_msg.children):
+                app_select_message(app, parent_msg.children[idx+1])
+        except IndexError:
+            pass
+
+def cmd_prev_sibling(app: AppState) -> None:
+    if (msg := app.selected_message) is not None and (parent_msg := msg.parent) is not None:
+        # find the previous sibling
+        try:
+            idx = parent_msg.children.index(msg)
+            if idx > 0:
+                app_select_message(app, parent_msg.children[idx-1])
+        except IndexError:
+            pass
+
+def cmd_mark_thread_as_read(app: AppState) -> None:
+    # recursively mark us and all children as read
+    # then jump to the next sibling
+    def iterate(message):
+        if message != None:
+            for child in message.children:
+                child.flags.read = True
+                db_save_message(app.db, msg)
+                iterate(child)
+    if (msg := app.selected_message) is not None:
+        iterate(msg)
+        # jump to the next sibling
+        cmd_next_sibling(app)
 
 def cmd_parent(app: AppState) -> None:
     if (msg := app.selected_message) is not None and (parent_msg := msg.parent) is not None:


### PR DESCRIPTION
This adds 3 new commands:

- Jump to the next sibling comment
- Jump to the previous sibling comment
- Mark the current thread as read and jump to the next sibling